### PR TITLE
ADHOC fix (security): removing sensitive creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,40 @@ This script provides functionality to create automatic snapshots of AWS EC2 inst
 Usage:
 ------
 
-1. Create a new user (https://console.aws.amazon.com/iam/?#users) having at least following permissions:
-     - CreateSnapshot
-     - DeleteSnapshot
-     - DescribeSnapshotAttribute
-     - DescribeSnapshots
-     - DescribeVolumeAttribute
-     - DescribeVolumeStatus
-     - DescribeVolumes
-     - DescribeInstances
-     - CreateTags
+1. Create an ec2 iam role (https://console.aws.amazon.com/iam/) having at least the following inline policy:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1403767721000",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CopySnapshot",
+                "ec2:CreateSnapshot",
+                "ec2:DeleteSnapshot",
+                "ec2:DescribeSnapshotAttribute",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeVolumeAttribute",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeInstances",
+                "ec2:CreateTags"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+```
 
-2. Define following environment variables containing the credentials of the new user:
+2. Assign the role created above to the target server, alternative (this is way worse approach cause it might expose your AWS credential to general public):
+Define following environment variables containing the credentials of the new user:
      - $AWS_BACKUP_ACCESS_KEY, i.e. AKIAIOSFODNN7EXAMPLE
-     - $AWS_BACKUP_SECRET_KEY, i.e. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+     - $AWS_BACKUP_SECRET_KEY, i.e. ****************************************
 
-3. Define a new environment variable $AWS_BACKUP_REGION containing the region of your machine, i.e. "eu-west-1"
+3. Install the `aws cli` on the target server
 
 4. By default the snapshots older than 30 days are deleted. If you want to change it, you can adjust the variable $daysToKeep at  the beginning of the script
 
@@ -30,5 +48,5 @@ Usage:
 6. If you want to run this script as a cron job, please add following line to the root's cronjobs (with your path to the script):
 
 ````
-       01 01 * * * export AWS_BACKUP_ACCESS_KEY="AKIAIOSFODNN7EXAMPLE" && export AWS_BACKUP_SECRET_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" && export AWS_BACKUP_REGION="eu-west-1" &&  /bin/bash /home/ec2-user/aws-backup/aws-backup.sh
+       01 01 * * * /bin/bash /home/ec2-user/aws-backup/aws-backup.sh
 ````


### PR DESCRIPTION
removing the dependency on storing sensitive credentials on the server.
Instead those can be provided by the IAM EC2 Role, so that machine is allowed
to perform the required operations.
Sensitive credentials were in every cron email that was send from the server
in question, this is a big security hole, this fix is supposed to close it
in the case if server is using the iam role like described in the README now.

Also changing code for the compatibility with recent `aws cli` versions.
The implementation might be cleaner, so the improvements are welcome,
I guess the best way would be to switch to python and really do all
processing by parsing json resonses from AWS API. This can be considered in
future work.