### PR TITLE
ADHOC fix (security): bugfix

### DIFF
--- a/aws-backup.sh
+++ b/aws-backup.sh
@@ -33,11 +33,10 @@ PATH=$PATH:/opt/aws/bin/
 instance=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id);
 
 # get the full information about the current instance
-fullDescription=$(aws ec2 describe-instances --instance-ids "$instance" --output text);
+fullDescription=$(aws ec2 describe-instances --instance-ids "$instance" --region "$region" --output text);
 
 # print the information
 printf "Instance info:\n----------------------\n%s\n----------------------\n" "$fullDescription";
-
 # get the name of the current instance
 instanceDescription=$(echo "$fullDescription" | grep Name);
 while read ignore1 ignore2 name; do


### PR DESCRIPTION
in the previous work the whole file was regactored to use newer version of
 aws cli and ec2 instance roles.
However there was also a bug introduced, the script was not functional without
aws cli pre-configured for specific environment, this commit fixes it.
Now all aws cli calls have the region argument specified.