### PR TITLE
ADHOC fix (Snapshots-Tagging): Fix tagging snapshots by constructing command with eval.

### DIFF
--- a/aws-backup.sh
+++ b/aws-backup.sh
@@ -70,7 +70,7 @@ while read -r volumeId; do
         fi
     done <<< "$instanceTags"
 
-    aws ec2 create-tags --resources "$snapshotId" --region "$region" --tags="$tagsArgs";
+    eval aws ec2 create-tags --resources "$snapshotId" --region "$region" --tags "$tagsArgs";
 done <<< "$volumeIds"
 
 ###################################


### PR DESCRIPTION
The aws api allows pushing tags to snapshots.
The --tags parameter requires a list of tags in the form
Key=<key>,Value=<value>.
In case of multiple tags the api takes the Key of the first tag
and the Value of the last flag and pushes only on tag. This is fixed by
constructing the command with eval

As part of the fix the "=" needs to be removed as its not part of the
syntax defined for the aws api